### PR TITLE
:sparkles: tentative to support MCM font file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.mp4
 *.osd
 .DS_Store
+.idea

--- a/backend/src/font/font_file.rs
+++ b/backend/src/font/font_file.rs
@@ -26,7 +26,7 @@ impl FontFile {
         match path.extension().map(|e| e.to_str().unwrap()) {
             None => panic!(),
             Some("mcm") => {
-                let characters = read_mcm(&path)?;
+                let characters = read_mcm(&path, CharacterSize::Large)?;
                 Ok(Self {
                     file_path: path,
                     character_count: characters.len() as u32,

--- a/backend/src/font/mcm_reader.rs
+++ b/backend/src/font/mcm_reader.rs
@@ -1,0 +1,46 @@
+use std::fs::File;
+use std::io;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+
+use image::{ImageBuffer, ImageError, Rgba};
+use image::error::{DecodingError, ImageFormatHint};
+
+use crate::font::FontFileError;
+
+const CHAR_HEIGHT: usize = 18;
+const CHAR_WIDTH: usize = 12;
+const GARBAGE: usize = 10;
+const NIBBLE_LEN: usize = 2;
+
+pub fn read_mcm<P: AsRef<Path>>(path: P) -> Result<Vec<ImageBuffer<Rgba<u8>, Vec<u8>>>, FontFileError> {
+    let file = BufReader::new(File::open(path).map_err(|e| FontFileError::FailedToOpen { source: e })?);
+
+    let mut lines = file.lines();
+    assert_eq!("MAX7456", lines.next().unwrap()
+        .map_err(|e| FontFileError::FailedToDecode { source: ImageError::Decoding(DecodingError::new(ImageFormatHint::Unknown, e)) })?.as_str()
+    );
+
+    let result = lines.collect::<io::Result<Vec<String>>>().map(|v| v.join(""))?;
+
+
+    let mcm_chars = result.chars().collect::<Vec<_>>();
+    let char_images = mcm_chars.chunks(CHAR_HEIGHT * CHAR_WIDTH * NIBBLE_LEN + GARBAGE * 8).map(|x| {
+        let pixels = x.iter().take(CHAR_HEIGHT * CHAR_WIDTH * NIBBLE_LEN).collect::<Vec<_>>()
+            .chunks(NIBBLE_LEN)
+            .map(|pixel| {
+                match pixel {
+                    &['0', '0'] => [0u8, 0, 0, 255],
+                    &['0', '1'] => [0, 0, 0, 0],
+                    &['1', '0'] => [255, 255, 255, 255],
+                    &['1', '1'] => [255, 255, 255, 0],
+                    _ => panic!()
+                }
+            })
+            .flatten()
+            .collect::<Vec<_>>();
+        ImageBuffer::from_raw(CHAR_WIDTH as u32, CHAR_HEIGHT as u32, pixels).unwrap()
+    })
+        .collect::<Vec<ImageBuffer<Rgba<u8>, Vec<u8>>>>();
+    Ok(char_images)
+}

--- a/backend/src/font/mcm_reader.rs
+++ b/backend/src/font/mcm_reader.rs
@@ -6,14 +6,16 @@ use std::path::Path;
 use image::{ImageBuffer, ImageError, Rgba};
 use image::error::{DecodingError, ImageFormatHint};
 
-use crate::font::FontFileError;
+use crate::font::{CharacterSize, FontFileError};
 
 const CHAR_HEIGHT: usize = 18;
 const CHAR_WIDTH: usize = 12;
 const GARBAGE: usize = 10;
 const NIBBLE_LEN: usize = 2;
 
-pub fn read_mcm<P: AsRef<Path>>(path: P) -> Result<Vec<ImageBuffer<Rgba<u8>, Vec<u8>>>, FontFileError> {
+pub fn read_mcm<P: AsRef<Path>>(path: P, size: CharacterSize) -> Result<Vec<ImageBuffer<Rgba<u8>, Vec<u8>>>, FontFileError> {
+    let width_factor = size.width() as usize / CHAR_WIDTH;
+    let height_factor = size.height() as usize / CHAR_HEIGHT;
     let file = BufReader::new(File::open(path).map_err(|e| FontFileError::FailedToOpen { source: e })?);
 
     let mut lines = file.lines();
@@ -30,16 +32,19 @@ pub fn read_mcm<P: AsRef<Path>>(path: P) -> Result<Vec<ImageBuffer<Rgba<u8>, Vec
             .chunks(NIBBLE_LEN)
             .map(|pixel| {
                 match pixel {
-                    &['0', '0'] => [0u8, 0, 0, 255],
-                    &['0', '1'] => [0, 0, 0, 0],
-                    &['1', '0'] => [255, 255, 255, 255],
-                    &['1', '1'] => [255, 255, 255, 0],
+                    &['0', '0'] => [0u8, 0, 0, 255].repeat(width_factor),
+                    &['0', '1'] => [0, 0, 0, 0].repeat(width_factor),
+                    &['1', '0'] => [255, 255, 255, 255].repeat(width_factor),
+                    &['1', '1'] => [255, 255, 255, 0].repeat(width_factor),
                     _ => panic!()
                 }
             })
             .flatten()
             .collect::<Vec<_>>();
-        ImageBuffer::from_raw(CHAR_WIDTH as u32, CHAR_HEIGHT as u32, pixels).unwrap()
+
+        let pixels_resized = pixels.chunks(CHAR_WIDTH * width_factor * 4).map(|chunk| chunk.repeat(height_factor)).flatten().collect::<Vec<_>>();
+
+        ImageBuffer::from_raw(CHAR_WIDTH as u32 * width_factor as u32, CHAR_HEIGHT as u32 * height_factor as u32, pixels_resized).unwrap()
     })
         .collect::<Vec<ImageBuffer<Rgba<u8>, Vec<u8>>>>();
     Ok(char_images)

--- a/backend/src/font/mod.rs
+++ b/backend/src/font/mod.rs
@@ -1,6 +1,7 @@
 mod dimensions;
 mod error;
 mod font_file;
+mod mcm_reader;
 
 pub use dimensions::{CharacterSize, FontType};
 pub use error::FontFileError;

--- a/ui/src/top_panel.rs
+++ b/ui/src/top_panel.rs
@@ -23,7 +23,7 @@ impl WalksnailOsdTool {
             .clicked()
         {
             if let Some(file_handles) = rfd::FileDialog::new()
-                .add_filter("Avatar files", &["mp4", "osd", "png", "srt"])
+                .add_filter("Avatar files", &["mp4", "osd", "png", "mcm", "srt"])
                 .pick_files()
             {
                 tracing::info!("Opened files {:?}", file_handles);

--- a/ui/src/util.rs
+++ b/ui/src/util.rs
@@ -62,10 +62,12 @@ impl WalksnailOsdTool {
     }
 
     pub fn import_font_file(&mut self, file_handles: &[PathBuf]) {
-        if let Some(font_file_path) = filter_file_with_extention(file_handles, "png") {
-            self.font_file = FontFile::open(font_file_path.clone()).ok();
-            self.config_changed = Some(Instant::now());
-        }
+        ["png","mcm"].iter().for_each(|ext|{
+            if let Some(font_file_path) = filter_file_with_extention(file_handles, ext) {
+                self.font_file = FontFile::open(font_file_path.clone()).ok();
+                self.config_changed = Some(Instant::now());
+            }
+        })
     }
 }
 


### PR DESCRIPTION
This is a proof of concept to support MCM file (the same flashed on FC)

At the moment this parse and emit correctly the characters, but need to be scaled to correct dimension, and some polishing (I don't know rust very well) pleas check.

This is work related to #36 and fix it importing the original BetaFlight font present in https://github.com/betaflight/betaflight-configurator/tree/master/resources/osd/2 folder.