### PR TITLE
Improvements to OSD options

### DIFF
--- a/backend/src/osd/frame.rs
+++ b/backend/src/osd/frame.rs
@@ -10,7 +10,7 @@ const BYTES_PER_GLYPH: usize = 2;
 const GRID_WIDTH: usize = 53;
 const _GRID_HEIGHT: usize = 20;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct Frame {
     pub time_millis: u32,
     pub glyphs: Vec<Glyph>,

--- a/backend/src/osd/options.rs
+++ b/backend/src/osd/options.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use derivative::Derivative;
 use serde::{Deserialize, Serialize};
 
-use crate::util::Coordinates;
+use crate::{font::CharacterSize, util::Coordinates};
 
 #[derive(Clone, Serialize, Deserialize, Derivative)]
 #[derivative(Default, Debug)]
@@ -15,6 +15,11 @@ pub struct OsdOptions {
     #[serde(skip)]
     pub osd_playback_speed_factor: f32,
     pub masked_grid_positions: HashSet<Coordinates<u32>>,
+    #[derivative(Default(value = "0.0"))]
+    #[serde(skip)]
+    pub osd_playback_offset: f32,
+    #[serde(skip)]
+    pub character_size: Option<CharacterSize>,
 }
 
 impl OsdOptions {

--- a/backend/src/overlay/iter.rs
+++ b/backend/src/overlay/iter.rs
@@ -49,7 +49,11 @@ impl<'a> FrameOverlayIter<'a> {
     ) -> Self {
         let mut osd_frames_iter = osd_frames.into_iter();
         let mut srt_frames_iter = srt_frames.into_iter();
-        let first_osd_frame = if osd_options.osd_playback_offset >= 0.0 { osd::Frame::default() } else { osd_frames_iter.next().unwrap() };
+        let first_osd_frame = if osd_options.osd_playback_offset >= 0.0 {
+            osd::Frame::default()
+        } else {
+            osd_frames_iter.next().unwrap()
+        };
         let first_srt_frame = srt_frames_iter.next().unwrap();
         let chroma_key =
             chroma_key.map(|c| Rgba([(c[0] * 255.0) as u8, (c[1] * 255.0) as u8, (c[2] * 255.0) as u8, 255]));
@@ -86,7 +90,8 @@ impl Iterator for FrameOverlayIter<'_> {
                 // If so advance the iterator over the OSD frames so we use the correct OSD frame
                 // for this video frame
                 if let Some(next_osd_frame) = self.osd_frames_iter.peek() {
-                    let next_osd_frame_secs = self.osd_options.osd_playback_offset + (next_osd_frame.time_millis as f32 / 1000.0);
+                    let next_osd_frame_secs =
+                        self.osd_options.osd_playback_offset + (next_osd_frame.time_millis as f32 / 1000.0);
                     if video_frame.timestamp > next_osd_frame_secs * self.osd_options.osd_playback_speed_factor {
                         self.current_osd_frame = self.osd_frames_iter.next().unwrap();
                     }

--- a/backend/src/overlay/iter.rs
+++ b/backend/src/overlay/iter.rs
@@ -49,7 +49,7 @@ impl<'a> FrameOverlayIter<'a> {
     ) -> Self {
         let mut osd_frames_iter = osd_frames.into_iter();
         let mut srt_frames_iter = srt_frames.into_iter();
-        let first_osd_frame = osd_frames_iter.next().unwrap();
+        let first_osd_frame = if osd_options.osd_playback_offset >= 0.0 { osd::Frame::default() } else { osd_frames_iter.next().unwrap() };
         let first_srt_frame = srt_frames_iter.next().unwrap();
         let chroma_key =
             chroma_key.map(|c| Rgba([(c[0] * 255.0) as u8, (c[1] * 255.0) as u8, (c[2] * 255.0) as u8, 255]));
@@ -86,7 +86,7 @@ impl Iterator for FrameOverlayIter<'_> {
                 // If so advance the iterator over the OSD frames so we use the correct OSD frame
                 // for this video frame
                 if let Some(next_osd_frame) = self.osd_frames_iter.peek() {
-                    let next_osd_frame_secs = next_osd_frame.time_millis as f32 / 1000.0;
+                    let next_osd_frame_secs = self.osd_options.osd_playback_offset + (next_osd_frame.time_millis as f32 / 1000.0);
                     if video_frame.timestamp > next_osd_frame_secs * self.osd_options.osd_playback_speed_factor {
                         self.current_osd_frame = self.osd_frames_iter.next().unwrap();
                     }

--- a/backend/src/overlay/mod.rs
+++ b/backend/src/overlay/mod.rs
@@ -4,4 +4,5 @@ mod srt;
 
 pub use iter::FrameOverlayIter;
 pub use osd::overlay_osd;
+pub use osd::get_character_size;
 pub use srt::overlay_srt_data;

--- a/backend/src/overlay/mod.rs
+++ b/backend/src/overlay/mod.rs
@@ -3,6 +3,5 @@ mod osd;
 mod srt;
 
 pub use iter::FrameOverlayIter;
-pub use osd::overlay_osd;
-pub use osd::get_character_size;
+pub use osd::{get_character_size, overlay_osd};
 pub use srt::overlay_srt_data;

--- a/backend/src/overlay/osd.rs
+++ b/backend/src/overlay/osd.rs
@@ -19,19 +19,29 @@ pub fn get_character_size(lines: u32) -> CharacterSize {
 #[inline]
 pub fn overlay_osd(image: &mut RgbaImage, osd_frame: &osd::Frame, font: &font::FontFile, osd_options: &OsdOptions) {
     // TODO: check if this can be run in parallel
-    let osd_character_size = get_character_size(image.height());
+    let osd_character_size = osd_options.character_size.clone().unwrap_or(get_character_size(image.height()));
     for character in &osd_frame.glyphs {
         if character.index == 0 || osd_options.get_mask(&character.grid_position) {
             continue;
         }
         if let Some(character_image) = font.get_character(character.index as usize, &osd_character_size) {
             let grid_position = &character.grid_position;
-            let (char_width, char_height) = character_image.dimensions();
+
+            // According to https://betaflight.com/docs/wiki/configurator/osd-tab
+            // INFO
+            // HD OSD defaults to a 53 column x 20 row grid of OSD elements.
+            // When the VTX is online BetaFlight will query via MSP Displayport to determine the optimum grid size and may update the grid to match what is supported by the digital VTX system
+            const ROW_COUNT: f32 = 20.0;
+            const COL_COUNT: f32 = 53.0;
+
+            let scale_height = image.height() as f32 / ROW_COUNT;
+            let scale_width = image.width() as f32 / COL_COUNT;
+
             overlay(
                 image,
                 &character_image,
-                (grid_position.x as i32 * char_width as i32 + osd_options.position.x).into(),
-                (grid_position.y as i32 * char_height as i32 + osd_options.position.y).into(),
+                (grid_position.x as f32 * scale_width + osd_options.position.x as f32) as i64,
+                (grid_position.y as f32 * scale_height + osd_options.position.y as f32) as i64,
             )
         }
     }

--- a/backend/src/overlay/osd.rs
+++ b/backend/src/overlay/osd.rs
@@ -19,7 +19,10 @@ pub fn get_character_size(lines: u32) -> CharacterSize {
 #[inline]
 pub fn overlay_osd(image: &mut RgbaImage, osd_frame: &osd::Frame, font: &font::FontFile, osd_options: &OsdOptions) {
     // TODO: check if this can be run in parallel
-    let osd_character_size = osd_options.character_size.clone().unwrap_or(get_character_size(image.height()));
+    let osd_character_size = osd_options
+        .character_size
+        .clone()
+        .unwrap_or(get_character_size(image.height()));
     for character in &osd_frame.glyphs {
         if character.index == 0 || osd_options.get_mask(&character.grid_position) {
             continue;

--- a/ui/src/central_panel.rs
+++ b/ui/src/central_panel.rs
@@ -1,6 +1,6 @@
 use std::time::Instant;
 
-use backend::util::Coordinates;
+use backend::{font::CharacterSize, util::Coordinates};
 use egui::{
     vec2, Button, CentralPanel, Checkbox, CollapsingHeader, Color32, CursorIcon, Grid, Image, Rect, RichText,
     ScrollArea, Sense, Slider, Stroke, Ui,
@@ -131,6 +131,47 @@ impl WalksnailOsdTool {
                                 .add(Checkbox::without_text(&mut self.osd_options.adjust_playback_speed))
                                 .changed()
                         });
+                        ui.end_row();
+
+                        // Enable playback offset only if playback speed adjustment is disabled, since it tries to fix basically the same problem
+                        if !self.osd_options.adjust_playback_speed && self.video_info.is_some() {
+                            ui.label("Adjust playback offset")
+                                .on_hover_text(tooltip_text("Start render OSD from N-th second. Usefull for splitted videos with lost OSD frames."));
+                            ui.horizontal(|ui| {
+                                ui
+                                .add(Slider::new(
+                                    &mut self.osd_options.osd_playback_offset,
+                                    0.0..=self.video_info.as_ref().map(|v| v.duration.as_secs_f32()).unwrap_or(0.0))
+                                    .text("Seconds"))
+                                    .on_hover_text("If your video file and osd file has the same duration, you probaby do not need this");
+
+                                if ui.add(Button::new(RichText::new("Auto")).small()).clicked() {
+                                    let difference = self.video_info.as_ref().unwrap().duration - self.osd_file.as_ref().unwrap().duration;
+                                    self.osd_options.osd_playback_offset = difference.as_secs_f32().abs();
+                                }
+                            });
+                            ui.end_row();
+                        }
+
+                        if self.video_info.is_some() {
+                            if self.osd_options.character_size.is_none() {
+                                self.osd_options.character_size = Some(backend::overlay::get_character_size(self.video_info.as_ref().unwrap().height));
+                            }
+
+                            egui::ComboBox::from_label("Character size")
+                                .selected_text(self.osd_options.character_size.clone().map_or(String::from("No video"), |s| format!("{:?}", s)))
+                                .width(100.0)
+                                .show_ui(ui, |ui| {
+                                    if self.osd_options.character_size.is_some() {
+                                        changed |= ui.selectable_value(self.osd_options.character_size.as_mut().unwrap(), CharacterSize::Race, "Race").changed();
+                                        changed |= ui.selectable_value(self.osd_options.character_size.as_mut().unwrap(), CharacterSize::Small, "Small").changed();
+                                        changed |= ui.selectable_value(self.osd_options.character_size.as_mut().unwrap(), CharacterSize::Large, "Large").changed();
+                                        changed |= ui.selectable_value(self.osd_options.character_size.as_mut().unwrap(), CharacterSize::XLarge, "Extra Large (2k)").changed();
+                                        changed |= ui.selectable_value(self.osd_options.character_size.as_mut().unwrap(), CharacterSize::Ultra, "Ultra Large (4k)").changed();
+                                    }
+                                });
+                            ui.end_row();
+                        }
                     });
             });
 

--- a/ui/src/side_panel.rs
+++ b/ui/src/side_panel.rs
@@ -1,5 +1,5 @@
 use backend::font::FontType;
-use egui::{CollapsingHeader, RichText, Ui};
+use egui::{CollapsingHeader, Color32, RichText, Ui};
 use egui_extras::{Column, TableBuilder};
 
 use super::WalksnailOsdTool;
@@ -118,6 +118,7 @@ impl WalksnailOsdTool {
     fn osd_info(&self, ui: &mut Ui) {
         let osd_file = self.osd_file.as_ref();
         let file_loaded = osd_file.is_some();
+        let video_file_loaded = self.video_info.is_some();
 
         CollapsingHeader::new(RichText::new("OSD file").heading())
             .icon(move |ui, opennes, response| circle_icon(ui, opennes, response, file_loaded))
@@ -183,11 +184,26 @@ impl WalksnailOsdTool {
                                     ui.label("Duration:");
                                 });
                                 row.col(|ui| {
-                                    if let Some(duration) = osd_file.map(|i| i.duration) {
-                                        ui.label(format_minutes_seconds(&duration));
-                                    } else {
-                                        ui.label("-");
-                                    }
+                                    ui.horizontal(|ui| {
+                                        if let Some(duration) = osd_file.map(|i| i.duration) {
+
+                                            if video_file_loaded {
+                                                let time_difference = self.video_info.as_ref().unwrap().duration - duration;
+                                                let abs_diff_secoinds = time_difference.as_secs_f32().abs();
+
+                                                if abs_diff_secoinds > 0.2 {
+                                                    ui
+                                                    .label(RichText::new("⚠").color(Color32::from_rgb(255, 200, 0)).strong())
+                                                    .on_hover_text( format!("OSD and Video files duration mismatch: {0}", abs_diff_secoinds));
+                                                }
+                                            }
+
+                                            ui.label(format_minutes_seconds(&duration));
+
+                                        } else {
+                                            ui.label("-");
+                                        }
+                                    });
                                 });
                             });
                         });

--- a/ui/src/side_panel.rs
+++ b/ui/src/side_panel.rs
@@ -186,20 +186,25 @@ impl WalksnailOsdTool {
                                 row.col(|ui| {
                                     ui.horizontal(|ui| {
                                         if let Some(duration) = osd_file.map(|i| i.duration) {
-
                                             if video_file_loaded {
-                                                let time_difference = self.video_info.as_ref().unwrap().duration - duration;
+                                                let time_difference =
+                                                    self.video_info.as_ref().unwrap().duration - duration;
                                                 let abs_diff_secoinds = time_difference.as_secs_f32().abs();
 
                                                 if abs_diff_secoinds > 0.2 {
-                                                    ui
-                                                    .label(RichText::new("⚠").color(Color32::from_rgb(255, 200, 0)).strong())
-                                                    .on_hover_text( format!("OSD and Video files duration mismatch: {0}", abs_diff_secoinds));
+                                                    ui.label(
+                                                        RichText::new("⚠")
+                                                            .color(Color32::from_rgb(255, 200, 0))
+                                                            .strong(),
+                                                    )
+                                                    .on_hover_text(format!(
+                                                        "OSD and Video files duration mismatch: {0}",
+                                                        abs_diff_secoinds
+                                                    ));
                                                 }
                                             }
 
                                             ui.label(format_minutes_seconds(&duration));
-
                                         } else {
                                             ui.label("-");
                                         }

--- a/ui/src/util.rs
+++ b/ui/src/util.rs
@@ -50,6 +50,8 @@ impl WalksnailOsdTool {
         if let Some(osd_file_path) = filter_file_with_extention(file_handles, "osd") {
             self.osd_file = OsdFile::open(osd_file_path.clone()).ok();
             self.osd_preview.preview_frame = 1;
+            self.osd_options.osd_playback_offset = 0.0;
+            self.osd_options.character_size = None;
         }
     }
 


### PR DESCRIPTION
## Playback offset

By default Avatar goggles split video files by 5 minutes (or by size 1.1GB). Video file splitted correctly but OSD file has approximately 5 seconds of lost data. Current option `Adjust playback speed` artificially increases OSD file duration and thus scales OSD frame time.

This changes introduce new type of solving this problem. Instead of streching OSD render - it just can be delayed by some amount of time to exactly match the video.

**Includes UI changes**:
 * Added slider for playback offset amount. Slider enabled only if `Adjust playback speed` setting is disabled.
    | | |
    | --- | ----------- |
    | <img width="494" alt="image" src="https://github.com/avsaase/walksnail-osd-tool/assets/5215122/eb82c1a1-d6fb-4f84-977a-3c6b9154c9be">| <img width="513" alt="image" src="https://github.com/avsaase/walksnail-osd-tool/assets/5215122/6b4a3d57-bce7-408d-942e-a50faee5a9e4">|
 * `auto` button calculates and set duration difference as playback offset amount.
 * Added warning icon next to OSD file duration to show user if it mismatches video duration
   <img width="438" alt="image" src="https://github.com/avsaase/walksnail-osd-tool/assets/5215122/5dc906bb-4232-4d0c-8dc8-1405ff687b1e">


## Character size setting

 As end user I want to have more control of how OSD data is rendered,
For my personal opinion, rendered for 1080p OSD overlay glyphs looks quite heavy. I want to have smaller character size for OSD overlay.

This PR gives user more control of rendering result.
Default size is set on video file load with size selection logic as it was during frame rendering.

### Different scaling

This commit also introduces a slightly different way to position overlay glyphs. You need only to know your OSD dimensions (rows and columns), this is something that should be in OSD file, however I didn't find a format specification so just took data from official website of betaflight. (TODO: should be checked with iNAV and other firmwares)


**Includes UI changes**:
 * UI for character size selection
    |Size | Result |
    | --- | ----------- |
    |Race| <img width="847" alt="image" src="https://github.com/avsaase/walksnail-osd-tool/assets/5215122/c23d1ed8-9b04-445b-bf73-a4b6923a55e3">|
    |Small|<img width="847" alt="image" src="https://github.com/avsaase/walksnail-osd-tool/assets/5215122/0b03af09-75b4-4f32-9c62-dc6c68c5b056">|
    |Large|<img width="849" alt="image" src="https://github.com/avsaase/walksnail-osd-tool/assets/5215122/b2da9c5a-712a-49bd-8999-ed8b163a1d98">|
    |XLarge|<img width="848" alt="image" src="https://github.com/avsaase/walksnail-osd-tool/assets/5215122/8b79e5ee-59ba-4407-a585-4c146369f1ea">|
    |Ultra Large|<img width="847" alt="image" src="https://github.com/avsaase/walksnail-osd-tool/assets/5215122/7916317f-7c63-498c-b49b-0a55439c8bf1">|