### PR TITLE
[Fix] Encoding result video with the same time scale as original

### DIFF
--- a/backend/src/ffmpeg/error.rs
+++ b/backend/src/ffmpeg/error.rs
@@ -11,6 +11,8 @@ pub enum VideoInfoError {
     #[error("Failed to read bitrate from video")]
     NoBitrate,
     #[error("Failed to read video duration from video")]
+    NoTimeScale,
+    #[error("Failed to read time scale value from video")]
     NoDuration,
     #[error("No stream in video file")]
     NoStream,

--- a/backend/src/ffmpeg/render.rs
+++ b/backend/src/ffmpeg/render.rs
@@ -40,6 +40,7 @@ pub fn start_video_render(
         video_info.width,
         video_info.height,
         video_info.frame_rate,
+        video_info.time_base,
         render_settings.bitrate_mbps,
         &render_settings.encoder,
         output_video,
@@ -116,6 +117,7 @@ pub fn spawn_encoder(
     width: u32,
     height: u32,
     frame_rate: f32,
+    time_base: u32,
     bitrate_mbps: u32,
     video_encoder: &Encoder,
     output_video: &PathBuf,
@@ -139,6 +141,7 @@ pub fn spawn_encoder(
         .pix_fmt("yuv420p")
         .codec_video(&video_encoder.name)
         .args(["-b:v", &format!("{}M", bitrate_mbps)])
+        .args(["-video_track_timescale", time_base.to_string().as_str()])
         .overwrite()
         .output(output_video.to_str().unwrap());
 

--- a/backend/src/ffmpeg/video_info.rs
+++ b/backend/src/ffmpeg/video_info.rs
@@ -9,6 +9,7 @@ pub struct VideoInfo {
     pub width: u32,
     pub height: u32,
     pub frame_rate: f32,
+    pub time_base: u32,
     pub bitrate: u32,
     pub duration: Duration,
     pub total_frames: u32,
@@ -57,12 +58,22 @@ impl TryFrom<FfProbe> for VideoInfo {
                 .ok_or(VideoInfoError::NoDuration)?,
         );
 
+        let time_base = {
+            let tbn_string = &stream.time_base;
+            let mut split = tbn_string.split('/');
+            split
+                .nth(1)
+                .and_then(|num| num.parse::<u32>().ok())
+                .ok_or(VideoInfoError::NoTimeScale)?
+        };
+
         let total_frames = (frame_rate * duration.as_secs_f32()) as u32;
 
         Ok(Self {
             width,
             height,
             frame_rate,
+            time_base,
             bitrate,
             duration,
             total_frames,


### PR DESCRIPTION
## Problem

Encoded videos with osd has different time scale values, this results problem when you trying to concatenate 2 mp4 video without re-enconding with ffmpeg. See [refence on stackoverflow](https://stackoverflow.com/questions/7333232/how-to-concatenate-two-mp4-files-using-ffmpeg)

## Before
```
ffprobe -hide_banner AvatarG0000.mp4
Input #0, mov,mp4,m4a,3gp,3g2,mj2, from 'AvatarG0000.mp4':
  Metadata:
    major_brand     : isom
    minor_version   : 512
    compatible_brands: isomiso2avc1mp41
    creation_time   : 2000-03-16T04:00:29.000000Z
    encoder         : Lavf58.76.100
  Duration: 00:01:03.27, start: 0.000000, bitrate: 30815 kb/s
  Stream #0:0[0x1](und): Video: h264 (High) (avc1 / 0x31637661), yuvj420p(pc, smpte170m, progressive), 1280x720, 30813 kb/s, 60 fps, 60 tbr, 90k tbn (default)
      Metadata:
        creation_time   : 2000-03-16T04:00:29.000000Z
        handler_name    : VideoHandler
        vendor_id       : [0][0][0][0]

ffprobe -hide_banner AvatarG0000_with_osd.mp4
Input #0, mov,mp4,m4a,3gp,3g2,mj2, from 'AvatarG0000_with_osd.mp4':
  Metadata:
    major_brand     : isom
    minor_version   : 512
    compatible_brands: isomiso2avc1mp41
    encoder         : Lavf61.2.100
  Duration: 00:01:03.27, start: 0.000000, bitrate: 41639 kb/s
  Stream #0:0[0x1](und): Video: h264 (High) (avc1 / 0x31637661), yuv420p(progressive), 1280x720, 41633 kb/s, 60 fps, 60 tbr, 15360 tbn (default)
      Metadata:
        handler_name    : VideoHandler
        vendor_id       : [0][0][0][0]
        encoder         : Lavc61.4.100 libx264
```
Original tbn: 90k
With OSD tbn: 15360 

## After
```
>ffprobe -hide_banner AvatarG0000_with_osd.mp4
Input #0, mov,mp4,m4a,3gp,3g2,mj2, from 'AvatarG0000_with_osd.mp4':
  Metadata:
    major_brand     : isom
    minor_version   : 512
    compatible_brands: isomiso2avc1mp41
    encoder         : Lavf61.2.100
  Duration: 00:01:03.27, start: 0.000000, bitrate: 41639 kb/s
  Stream #0:0[0x1](und): Video: h264 (High) (avc1 / 0x31637661), yuv420p(progressive), 1280x720, 41633 kb/s, 60 fps, 60 tbr, 90k tbn (default)
      Metadata:
        handler_name    : VideoHandler
        vendor_id       : [0][0][0][0]
        encoder         : Lavc61.4.100 libx264
```

With OSD tbn: 90k

## Reviewer
@avsaase 