### PR TITLE
Fix video not being playable on MacOS when encoded with hevc_videotoolbox

### DIFF
--- a/backend/src/ffmpeg/encoders.rs
+++ b/backend/src/ffmpeg/encoders.rs
@@ -24,15 +24,21 @@ pub struct Encoder {
     pub codec: Codec,
     pub hardware: bool,
     pub detected: bool,
+    pub extra_args: Vec<String>
 }
 
 impl Encoder {
     fn new(name: &str, codec: Codec, hardware: bool) -> Self {
+        Self::new_with_extra_args(name, codec, hardware, &[])
+    }
+
+    fn new_with_extra_args(name: &str, codec: Codec, hardware: bool, extra_args: &[&str]) -> Self {
         Self {
             name: name.to_string(),
             codec,
             hardware,
             detected: false,
+            extra_args: extra_args.iter().map(|&s| s.to_string()).collect(),
         }
     }
 
@@ -77,7 +83,10 @@ impl Encoder {
             Encoder::new("hevc_v4l2m2m", Codec::H265, true),
 
             #[cfg(target_os = "macos")]
-            Encoder::new("hevc_videotoolbox", Codec::H265, true),
+            Encoder::new_with_extra_args(
+                "hevc_videotoolbox", Codec::H265, true, 
+                &["-tag:v", "hvc1"] // Apple QuickTime player on Mac only supports hvc1
+            ),
         ];
 
         all_encoders

--- a/backend/src/ffmpeg/render.rs
+++ b/backend/src/ffmpeg/render.rs
@@ -139,6 +139,7 @@ pub fn spawn_encoder(
         .pix_fmt("yuv420p")
         .codec_video(&video_encoder.name)
         .args(["-b:v", &format!("{}M", bitrate_mbps)])
+        .args(&video_encoder.extra_args)
         .overwrite()
         .output(output_video.to_str().unwrap());
 

--- a/backend/src/ffmpeg/render_settings.rs
+++ b/backend/src/ffmpeg/render_settings.rs
@@ -21,6 +21,7 @@ impl Default for RenderSettings {
                 codec: Codec::H264,
                 hardware: false,
                 detected: false,
+                extra_args: Vec::new(),
             },
             selected_encoder_idx: 0,
             show_undetected_encoders: false,


### PR DESCRIPTION
# Problem

Apple QuickTime player on Mac only supports hvc1. Finder's Quick Look feature also uses QuickTime.

As of now a video encoded using hevc_videotoolbox encoder cannot be played on MacOS without using a 3rd party player.

# Solution

Force avc1 (instead of default hev1) tag when encoding a video using MacOS-native hardware encoder.