### PR TITLE
Added option to force 4:3 aspect ratio

### DIFF
--- a/backend/src/ffmpeg/render_settings.rs
+++ b/backend/src/ffmpeg/render_settings.rs
@@ -9,6 +9,7 @@ pub struct RenderSettings {
     pub show_undetected_encoders: bool,
     pub bitrate_mbps: u32,
     pub upscale: bool,
+    pub rescale_to_4x3_aspect: bool,
     pub use_chroma_key: bool,
     pub chroma_key: [f32; 3],
 }
@@ -26,6 +27,7 @@ impl Default for RenderSettings {
             show_undetected_encoders: false,
             bitrate_mbps: 40,
             upscale: false,
+            rescale_to_4x3_aspect: false,
             use_chroma_key: false,
             chroma_key: [1.0 / 255.0, 177.0 / 255.0, 64.0 / 255.0],
         }

--- a/ui/src/central_panel.rs
+++ b/ui/src/central_panel.rs
@@ -381,6 +381,10 @@ impl WalksnailOsdTool {
                         changed |= ui.add(Checkbox::without_text(&mut self.render_settings.upscale)).changed();
                         ui.end_row();
 
+                        ui.label("Rescale to 4:3 aspect ratio").on_hover_text(tooltip_text("Rescale the output video to 4:3 aspect ratio, useful when you have 4:3 camera and recording is done by VRX in \"4:3 Fullscreen\" mode."));
+                        changed |= ui.add(Checkbox::without_text(&mut self.render_settings.rescale_to_4x3_aspect)).changed();
+                        ui.end_row();
+
                         ui.label("Chroma key").on_hover_text(tooltip_text("Render the video with a chroma key instead of the input video so the OSD can be overlay in video editing software."));
                         ui.horizontal(|ui| {
                             changed |= ui.add(Checkbox::without_text(&mut self.render_settings.use_chroma_key)).changed();


### PR DESCRIPTION
# Problem

Setup:
1. SkyZone sky04x v2 (not PRO) with 4:3 screen
2. Walksnail VRX
3. Walksnail Micro V2 Cam with 4:3 sensor

Situation:
* Sky04x goggles have 4:3 display but they get hdmi input in 16:9 format and scale it to fill the screen.
* In this case you have to use 4:3-FULL display mode in Walksnail VRX settings which also scales image coming from camera to occupy full screen. Otherwise the image would appear stretched in the goggles.
* Now you have 16:9 DVR recording done by the VRX but the camera image is stretched in width.
* To fix it you have to rescale the video bringing the aspect ratio back to 4:3.

# Solution

Added a new checkbox which enables rescaling the final video (after overlaying the OSD) to 4:3 aspect ratio thus effectively shrinking it horizontally. The added ffmpeg option `-aspect` doesn't really change final resolution rather just specify pixel aspect ratio in the mp4 container.