### PR TITLE
fix(ci): specify package for cargo bundle in workspace

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Build (MacOS)
         if: ${{ matrix.targets.name == 'macos-intel' || matrix.targets.name == 'macos-arm'}}
-        run: cargo build --release --target ${{ matrix.targets.target }} --features macos-app-bundle
+        run: cargo build --release --target ${{ matrix.targets.target }} -p walksnail-osd-tool --features macos-app-bundle
 
       - name: Extract ffmpeg
         run: |
@@ -103,7 +103,7 @@ jobs:
       - name: Create Mac App bundle
         if: ${{ matrix.targets.name == 'macos-intel' || matrix.targets.name == 'macos-arm'}}
         run: |
-          cargo bundle --release --target ${{ matrix.targets.target }} --features macos-app-bundle
+          cargo bundle --release --target ${{ matrix.targets.target }} --features macos-app-bundle -p walksnail-osd-tool
           cp ${{ github.workspace }}/ext/ffmpeg/${{ matrix.targets.name }}/ffmpeg ${{ github.workspace }}/target/${{ matrix.targets.target }}/release/bundle/osx/Walksnail\ OSD\ Tool.app/Contents/MacOS/ffmpeg
           cp ${{ github.workspace }}/ext/ffmpeg/${{ matrix.targets.name }}/ffprobe ${{ github.workspace }}/target/${{ matrix.targets.target }}/release/bundle/osx/Walksnail\ OSD\ Tool.app/Contents/MacOS/ffprobe
           cd ${{ github.workspace }}/target/${{ matrix.targets.target }}/release/bundle/osx/


### PR DESCRIPTION
## Problem

CI fails with `error: No root package found in workspace` when running `cargo bundle` for macOS builds.

## Root Cause

The project uses a Cargo workspace (`members = ["ui", "backend"]`) with no root package. When `cargo bundle` runs from the workspace root without a package specified, Cargo cannot determine which crate to bundle.

## Solution

Add `-p walksnail-osd-tool` to explicitly specify the package to bundle. This matches the pattern already used for the Windows build (`cargo wix --package walksnail-osd-tool`).

## Verification

Tested locally:
- Without `-p`: fails with "No root package found in workspace"
- With `-p walksnail-osd-tool`: succeeds and produces the app bundle

Made with [Cursor](https://cursor.com)