### PR TITLE
feat(srt): parse Caddx Ascent SRT format

### DIFF
--- a/backend/src/srt/frame.rs
+++ b/backend/src/srt/frame.rs
@@ -21,6 +21,62 @@ pub struct SrtFrameData {
     pub distance: u32,
 }
 
+/// SRT frame data emitted by the Caddx Ascent goggles. The format is nearly
+/// identical to Walksnail, but the channel field is replaced with a raw
+/// frequency in Hz (e.g. `Hz:5695000`) instead of a channel index (`CH:1`).
+///
+/// See https://github.com/avsaase/walksnail-osd-tool/issues/65
+#[derive(Debug, FromStr, Clone, PartialEq)]
+#[display("Signal:{signal} Hz:{frequency_hz} FlightTime:{flight_time} SBat:{sky_bat}V GBat:{ground_bat}V Delay:{latency}ms Bitrate:{bitrate_mbps}Mbps Distance:{distance}m")]
+pub struct SrtFrameDataAscent {
+    pub signal: u8,
+    pub frequency_hz: u32,
+    pub flight_time: u32,
+    pub sky_bat: f32,
+    pub ground_bat: f32,
+    pub latency: u32,
+    pub bitrate_mbps: f32,
+    pub distance: u32,
+}
+
+impl SrtFrameDataAscent {
+    /// Convert an Ascent frame into the common [`SrtFrameData`] representation.
+    /// The frequency is mapped to the nearest 5.8 GHz Walksnail R-band channel
+    /// when possible; otherwise the channel is reported as `0` so downstream
+    /// rendering keeps working.
+    pub fn into_common(self) -> SrtFrameData {
+        SrtFrameData {
+            signal: self.signal,
+            channel: freq_hz_to_channel(self.frequency_hz).unwrap_or(0),
+            flight_time: self.flight_time,
+            sky_bat: self.sky_bat,
+            ground_bat: self.ground_bat,
+            latency: self.latency,
+            bitrate_mbps: self.bitrate_mbps,
+            distance: self.distance,
+        }
+    }
+}
+
+/// Map a 5.8 GHz frequency (in Hz) to the matching Walksnail R-band channel
+/// (`1`..=`8`). Returns `None` if the frequency does not match a known
+/// Walksnail channel within a 5 MHz tolerance.
+///
+/// Walksnail uses the standard FPV R-band:
+/// R1=5658, R2=5695, R3=5732, R4=5769, R5=5806, R6=5843, R7=5880, R8=5917 MHz.
+pub fn freq_hz_to_channel(frequency_hz: u32) -> Option<u8> {
+    // R-band channels in MHz, indexed by `channel - 1`.
+    const R_BAND_MHZ: [u32; 8] = [5658, 5695, 5732, 5769, 5806, 5843, 5880, 5917];
+    const TOLERANCE_MHZ: u32 = 5;
+
+    let freq_mhz = frequency_hz / 1_000;
+    R_BAND_MHZ
+        .iter()
+        .enumerate()
+        .find(|(_, ch_mhz)| freq_mhz.abs_diff(**ch_mhz) <= TOLERANCE_MHZ)
+        .map(|(i, _)| (i as u8) + 1)
+}
+
 #[derive(Debug, FromStr, Clone, PartialEq)]
 #[display("CH:{channel} MCS:{signal} SP[ {sp1} {sp2}  {sp3} {sp4}] GP[ {gp1}  {gp2}  {gp3}  {gp4}] GTP:{gtp} GTP0:{gtp0} STP:{stp} STP0:{stp0} GSNR:{gsnr} SSNR:{ssnr} Gtemp:{gtemp} Stemp:{stemp} Delay:{latency}ms Frame:{frame}  Gerr:{gerr} SErr:{serr} {serr_ext}, [iso:{iso},mode={iso_mode}, exp:{iso_exp}] [gain:{gain} exp:{gain_exp}ms]")]
 pub struct SrtDebugFrameData {
@@ -143,5 +199,87 @@ mod tests {
                 gain_exp: 0.0
             }
         )
+    }
+
+    #[test]
+    fn parse_ascent_srt_frame_data() {
+        let line = "Signal:3 Hz:5695000 FlightTime:0 SBat:4.5V GBat:8.7V Delay:32ms Bitrate:13.3Mbps Distance:0m";
+        let parsed = line.parse::<SrtFrameDataAscent>();
+        assert_eq!(
+            parsed.expect("Failed to parse Ascent SRT frame data"),
+            SrtFrameDataAscent {
+                signal: 3,
+                frequency_hz: 5_695_000,
+                flight_time: 0,
+                sky_bat: 4.5,
+                ground_bat: 8.7,
+                latency: 32,
+                bitrate_mbps: 13.3,
+                distance: 0,
+            }
+        )
+    }
+
+    #[test]
+    fn ascent_into_common_maps_frequency_to_r_band_channel() {
+        let ascent = SrtFrameDataAscent {
+            signal: 3,
+            frequency_hz: 5_695_000,
+            flight_time: 0,
+            sky_bat: 4.5,
+            ground_bat: 8.7,
+            latency: 32,
+            bitrate_mbps: 13.3,
+            distance: 0,
+        };
+        let common = ascent.into_common();
+        assert_eq!(
+            common,
+            SrtFrameData {
+                signal: 3,
+                channel: 2, // 5695 MHz = R2
+                flight_time: 0,
+                sky_bat: 4.5,
+                ground_bat: 8.7,
+                latency: 32,
+                bitrate_mbps: 13.3,
+                distance: 0,
+            }
+        )
+    }
+
+    #[test]
+    fn freq_hz_to_channel_maps_all_r_band_channels() {
+        let pairs = [
+            (5_658_000, 1),
+            (5_695_000, 2),
+            (5_732_000, 3),
+            (5_769_000, 4),
+            (5_806_000, 5),
+            (5_843_000, 6),
+            (5_880_000, 7),
+            (5_917_000, 8),
+        ];
+        for (hz, expected_ch) in pairs {
+            assert_eq!(freq_hz_to_channel(hz), Some(expected_ch), "{} Hz", hz);
+        }
+    }
+
+    #[test]
+    fn freq_hz_to_channel_returns_none_for_unknown_frequency() {
+        // 2.4 GHz, well outside the 5.8 GHz R-band table.
+        assert_eq!(freq_hz_to_channel(2_400_000_000), None);
+        // Halfway between R2 and R3 — outside tolerance.
+        assert_eq!(freq_hz_to_channel(5_713_000), None);
+    }
+
+    #[test]
+    fn ascent_does_not_match_walksnail_format() {
+        // Walksnail format must never accidentally parse as Ascent and vice-versa.
+        let walksnail = "Signal:4 CH:7 FlightTime:0 SBat:16.7V GBat:12.5V Delay:25ms Bitrate:25.0Mbps Distance:1m";
+        assert!(walksnail.parse::<SrtFrameDataAscent>().is_err());
+
+        let ascent = "Signal:3 Hz:5695000 FlightTime:0 SBat:4.5V GBat:8.7V Delay:32ms Bitrate:13.3Mbps Distance:0m";
+        assert!(ascent.parse::<SrtFrameData>().is_err());
     }
 }

--- a/backend/src/srt/srt_file.rs
+++ b/backend/src/srt/srt_file.rs
@@ -4,7 +4,7 @@ use derivative::Derivative;
 
 use super::{
     error::SrtFileError,
-    frame::{SrtDebugFrameData, SrtFrame},
+    frame::{SrtDebugFrameData, SrtFrame, SrtFrameDataAscent},
     SrtFrameData,
 };
 
@@ -28,7 +28,22 @@ impl SrtFile {
             .iter()
             .map(|i| -> Result<SrtFrame, SrtFileError> {
                 let debug_data = i.text.parse::<SrtDebugFrameData>().ok();
-                let data = i.text.parse::<SrtFrameData>().ok();
+                // Try the Walksnail format first. If that fails and the line
+                // looks like a Caddx Ascent frame (`Hz:` field instead of
+                // `CH:`), try the Ascent variant and convert it to the common
+                // representation. The cheap `contains("Hz:")` pre-check keeps
+                // the hot path Walksnail-only.
+                // See https://github.com/avsaase/walksnail-osd-tool/issues/65
+                let data = i.text.parse::<SrtFrameData>().ok().or_else(|| {
+                    if i.text.contains("Hz:") {
+                        i.text
+                            .parse::<SrtFrameDataAscent>()
+                            .ok()
+                            .map(SrtFrameDataAscent::into_common)
+                    } else {
+                        None
+                    }
+                });
 
                 if debug_data.is_some() {
                     has_debug = true;


### PR DESCRIPTION
Closes #65.

## Problem

The Caddx Ascent goggles produce an SRT file that's almost identical to Walksnail's, but replace the channel index with a raw frequency in Hz:

- Walksnail: `Signal:4 CH:1 FlightTime:0 SBat:4.7V GBat:7.2V Delay:32ms Bitrate:25Mbps Distance:7m`
- Ascent:    `Signal:3 Hz:5695000 FlightTime:0 SBat:4.5V GBat:8.7V Delay:32ms Bitrate:13.3Mbps Distance:0m`

The `#[display(...)]` derive on `SrtFrameData` is strict, so every Ascent line fails to parse and the file ends up looking empty.

## Fix

- New `SrtFrameDataAscent` struct with an Ascent display pattern (`Hz:{frequency_hz}` in place of `CH:{channel}`).
- `freq_hz_to_channel` helper that maps the 5.8 GHz R-band back to the Walksnail channel index (R1=5658 .. R8=5917 MHz, +/- 5 MHz tolerance). Unknown frequencies fall back to `0` so rendering keeps working.
- In `SrtFile::open`, on a Walksnail parse miss we only attempt the Ascent variant when the line contains `Hz:`, keeping the hot path Walksnail-only.

## Tests

Added unit tests in `backend/src/srt/frame.rs`:

- Parses the Ascent example line from the issue.
- Converts Ascent -> common `SrtFrameData` and verifies the channel mapping (5695 MHz -> R2).
- Maps every R-band frequency to its expected channel.
- Returns `None` for out-of-band / mid-band frequencies.
- Confirms the two formats are mutually exclusive (Walksnail line doesn't parse as Ascent and vice-versa).

Existing Walksnail parse tests are untouched.